### PR TITLE
feat(sqs): `fifo` queues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.16.0
 	github.com/aws/smithy-go v1.10.0
 	github.com/goccy/go-json v0.9.4
+	github.com/google/uuid v1.3.0
 	github.com/roadrunner-server/api/v2 v2.9.0
 	github.com/roadrunner-server/errors v1.1.1
 	github.com/roadrunner-server/sdk/v2 v2.9.1

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/sqsjobs/consumer.go
+++ b/sqsjobs/consumer.go
@@ -361,7 +361,7 @@ func (c *Consumer) Resume(_ context.Context, p string) {
 }
 
 func (c *Consumer) handleItem(ctx context.Context, msg *Item) error {
-	d, err := msg.pack(c.queueURL, c.messageGroupID)
+	d, err := msg.pack(c.queueURL, c.queue, c.messageGroupID)
 	if err != nil {
 		return err
 	}
@@ -429,12 +429,14 @@ func isInAWS() bool {
 func createQueue(client *sqs.Client, queueName *string, attributes map[string]string, tags map[string]string) (*string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	out, err := client.CreateQueue(context.Background(), &sqs.CreateQueueInput{QueueName: queueName, Attributes: attributes, Tags: tags})
+	out, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{QueueName: queueName, Attributes: attributes, Tags: tags})
 	if err != nil {
 		if oErr, ok := (err).(*smithy.OperationError); ok { //nolint:errorlint
 			if rErr, ok := oErr.Err.(*awshttp.ResponseError); ok { //nolint:errorlint
 				if _, ok := rErr.Unwrap().(*types.QueueNameExists); ok { //nolint:errorlint
-					res, errQ := client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+					ctxGet, cancelGet := context.WithTimeout(context.Background(), time.Second*30)
+					defer cancelGet()
+					res, errQ := client.GetQueueUrl(ctxGet, &sqs.GetQueueUrlInput{
 						QueueName: queueName,
 					}, func(_ *sqs.Options) {})
 					if errQ != nil {

--- a/sqsjobs/item.go
+++ b/sqsjobs/item.go
@@ -199,7 +199,7 @@ func (i *Item) pack(queueURL, origQueue *string, mg string) (*sqs.SendMessageInp
 	return &sqs.SendMessageInput{
 		MessageBody:            aws.String(i.Payload),
 		QueueUrl:               queueURL,
-		DelaySeconds:           int32(i.Options.Delay),
+		DelaySeconds:           delay(origQueue, int32(i.Options.Delay)),
 		MessageDeduplicationId: dedup(i.ID(), origQueue),
 		// message group used for the FIFO
 		MessageGroupId: mgr(mg),
@@ -285,4 +285,12 @@ func dedup(dedup string, origQueue *string) *string {
 	}
 
 	return nil
+}
+
+func delay(origQueue *string, delay int32) int32 {
+	if strings.HasSuffix(*origQueue, fifoSuffix) {
+		return 0
+	}
+
+	return delay
 }


### PR DESCRIPTION
# Reason for This PR

- closes: https://github.com/roadrunner-server/roadrunner/issues/906

## Description of Changes

- Amazon SQS SendMessage API supported (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html)
Limitations: since the `MessageSystemAttribute` is used only for the AWS trace, it will be supported by demand.
- To use `FifoQueue` Job ID should be unique across the queue.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
