### PR TITLE
ci: wait for localstack/toxiproxy readiness in durability workflow

### DIFF
--- a/.github/workflows/linux_durability.yml
+++ b/.github/workflows/linux_durability.yml
@@ -68,7 +68,8 @@ jobs:
         run: |
           cd tests
           docker compose -f env/docker-compose-sqs-local.yaml up -d --remove-orphans
-          sleep 30
+          timeout 120 bash -c 'until curl -sf 127.0.0.1:4566/_localstack/health >/dev/null; do sleep 2; done'
+          timeout 60 bash -c 'until curl -sf 127.0.0.1:8474/proxies >/dev/null; do sleep 1; done'
           mkdir ./coverage-ci
           go test -timeout 20m -v -race -cover -tags=debug -failfast -coverpkg=github.com/roadrunner-server/sqs/v6 -coverprofile=./coverage-ci/sqs_dur.out -covermode=atomic jobs_sqs_durability_test.go
           docker compose -f env/docker-compose-sqs-local.yaml down

--- a/tests/env/docker-compose-sqs-local.yaml
+++ b/tests/env/docker-compose-sqs-local.yaml
@@ -1,10 +1,10 @@
 services:
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:2026.06.3
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
 
   toxicproxy:
-    image: shopify/toxiproxy:latest
+    image: shopify/toxiproxy:2.1.4
     network_mode: "host"

--- a/tests/env/docker-compose-sqs-local.yaml
+++ b/tests/env/docker-compose-sqs-local.yaml
@@ -1,6 +1,8 @@
 services:
   localstack:
-    image: localstack/localstack:2026.06.3
+    # last Community release line that runs without a LOCALSTACK_AUTH_TOKEN;
+    # the 2026.x calver images exit with a license error on boot
+    image: localstack/localstack:4.14
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range


### PR DESCRIPTION
The durability job used a bare sleep 30 before running tests; localstack often is not ready by then and CreateQueue times out. Poll the localstack health endpoint and the toxiproxy API instead, and pin the localstack/toxiproxy images.